### PR TITLE
(refactor) Enable afterPostSubmission retrieve insurance policy to create consommation for open global bills

### DIFF
--- a/omod/src/main/java/org/openmrs/module/mohbilling/rest/model/PostSubmissionObs.java
+++ b/omod/src/main/java/org/openmrs/module/mohbilling/rest/model/PostSubmissionObs.java
@@ -8,6 +8,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PostSubmissionObs {
     private List<ObsIdentifier> obs = new ArrayList<>();
+    private String insurancePolicyNumber;
 
     public static class ObsIdentifier {
         private String uuid;
@@ -27,5 +28,13 @@ public class PostSubmissionObs {
 
     public void setObs(List<ObsIdentifier> obs) {
         this.obs = obs;
+    }
+
+    public String getInsurancePolicyNumber() {
+        return insurancePolicyNumber;
+    }
+
+    public void setInsurancePolicyNumber(String insurancePolicyNumber) {
+        this.insurancePolicyNumber = insurancePolicyNumber;
     }
 }


### PR DESCRIPTION
Work done

- Added insurancePolicyNumber field to PostSubmissionObs model to allow direct specification of insurance policy
- Enhanced AfterPostSubmissionController to prioritize insurance policy number from request payload
- Implemented fallback logic to retrieve insurance policy from patient observations when not provided in payload