### PR TITLE
feat: implement soft delete (retire) for InsurancePolicy via REST purge method

### DIFF
--- a/api/src/main/java/org/openmrs/module/mohbilling/db/BillingDAO.java
+++ b/api/src/main/java/org/openmrs/module/mohbilling/db/BillingDAO.java
@@ -739,4 +739,6 @@ public interface BillingDAO {
 	List<BillPayment> getBillPaymentsByPatientBill(PatientBill patientBill);
 
 	Beneficiary getBeneficiary(Integer beneficiaryId);
+
+	List<InsurancePolicy> getInsurancePoliciesByPagination(int offset, int limit);
 }

--- a/api/src/main/java/org/openmrs/module/mohbilling/db/BillingDAO.java
+++ b/api/src/main/java/org/openmrs/module/mohbilling/db/BillingDAO.java
@@ -741,4 +741,6 @@ public interface BillingDAO {
 	Beneficiary getBeneficiary(Integer beneficiaryId);
 
 	List<InsurancePolicy> getInsurancePoliciesByPagination(int offset, int limit);
+
+	int getInsurancePolicyCount();
 }

--- a/api/src/main/java/org/openmrs/module/mohbilling/db/hibernate/HibernateBillingDAO.java
+++ b/api/src/main/java/org/openmrs/module/mohbilling/db/hibernate/HibernateBillingDAO.java
@@ -1952,4 +1952,16 @@ public class HibernateBillingDAO implements BillingDAO {
                 .createCriteria(BillPayment.class)
                 .add(Restrictions.eq("patientBill", patientBill)).list();
     }
+
+    @Override
+    public List<InsurancePolicy> getInsurancePoliciesByPagination(int offset, int limit) {
+        Criteria criteria = sessionFactory.getCurrentSession()
+                .createCriteria(InsurancePolicy.class)
+                .add(Restrictions.eq("retired", false))
+                .setFirstResult(offset)
+                .setMaxResults(limit)
+                .addOrder(Order.desc("createdDate"));
+
+        return criteria.list();
+    }
 }

--- a/api/src/main/java/org/openmrs/module/mohbilling/db/hibernate/HibernateBillingDAO.java
+++ b/api/src/main/java/org/openmrs/module/mohbilling/db/hibernate/HibernateBillingDAO.java
@@ -1964,4 +1964,13 @@ public class HibernateBillingDAO implements BillingDAO {
 
         return criteria.list();
     }
+
+    @Override
+    public int getInsurancePolicyCount() {
+        Criteria criteria = sessionFactory.getCurrentSession()
+                .createCriteria(InsurancePolicy.class)
+                .add(Restrictions.eq("retired", false))
+                .setProjection(Projections.rowCount());
+        return (int) criteria.uniqueResult();
+    }
 }

--- a/api/src/main/java/org/openmrs/module/mohbilling/impl/BillingServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/mohbilling/impl/BillingServiceImpl.java
@@ -1055,4 +1055,9 @@ public class BillingServiceImpl implements BillingService {
     public Beneficiary getBeneficiary(Integer beneficiaryId) {
         return billingDAO.getBeneficiary(beneficiaryId);
     }
+
+    @Override
+    public List<InsurancePolicy> getInsurancePoliciesByPagination(int offset, int limit) {
+        return billingDAO.getInsurancePoliciesByPagination(offset, limit);
+    }
 }

--- a/api/src/main/java/org/openmrs/module/mohbilling/impl/BillingServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/mohbilling/impl/BillingServiceImpl.java
@@ -1060,4 +1060,9 @@ public class BillingServiceImpl implements BillingService {
     public List<InsurancePolicy> getInsurancePoliciesByPagination(int offset, int limit) {
         return billingDAO.getInsurancePoliciesByPagination(offset, limit);
     }
+
+    @Override
+    public int getInsurancePolicyCount() {
+        return billingDAO.getInsurancePolicyCount();
+    }
 }

--- a/api/src/main/java/org/openmrs/module/mohbilling/service/BillingService.java
+++ b/api/src/main/java/org/openmrs/module/mohbilling/service/BillingService.java
@@ -701,4 +701,6 @@ public interface BillingService {
 	List<BillPayment> getBillPaymentsByPatientBill(PatientBill patientBill);
 
 	Beneficiary getBeneficiary(Integer beneficiaryId);
+
+	List<InsurancePolicy> getInsurancePoliciesByPagination(int offset, int limit);
 }

--- a/api/src/main/java/org/openmrs/module/mohbilling/service/BillingService.java
+++ b/api/src/main/java/org/openmrs/module/mohbilling/service/BillingService.java
@@ -703,4 +703,6 @@ public interface BillingService {
 	Beneficiary getBeneficiary(Integer beneficiaryId);
 
 	List<InsurancePolicy> getInsurancePoliciesByPagination(int offset, int limit);
+
+	int getInsurancePolicyCount();
 }

--- a/omod/src/main/java/org/openmrs/module/mohbilling/rest/resource/InsurancePolicyResource.java
+++ b/omod/src/main/java/org/openmrs/module/mohbilling/rest/resource/InsurancePolicyResource.java
@@ -26,6 +26,7 @@ import org.openmrs.module.webservices.rest.web.representation.FullRepresentation
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.AlreadyPaged;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
@@ -139,14 +140,18 @@ public class InsurancePolicyResource extends DelegatingCrudResource<InsurancePol
         return new NeedsPaging<>(insurancePolicies, context);
     }
 
+
     @Override
-    public NeedsPaging<InsurancePolicy> doGetAll(RequestContext context) throws ResponseException {
+    public PageableResult doGetAll(RequestContext context) throws ResponseException {
         int startIndex = context.getStartIndex();
         int limit = context.getLimit();
 
         List<InsurancePolicy> policies = Context.getService(BillingService.class)
                 .getInsurancePoliciesByPagination(startIndex, limit);
 
-        return new NeedsPaging<>(policies, context);
+        int totalCount = Context.getService(BillingService.class).getInsurancePolicyCount();
+        boolean hasMore = (startIndex + limit) < totalCount;
+
+        return new AlreadyPaged<InsurancePolicy>(context, policies, hasMore, (long) totalCount);
     }
 }

--- a/omod/src/main/java/org/openmrs/module/mohbilling/rest/resource/InsurancePolicyResource.java
+++ b/omod/src/main/java/org/openmrs/module/mohbilling/rest/resource/InsurancePolicyResource.java
@@ -141,12 +141,20 @@ public class InsurancePolicyResource extends DelegatingCrudResource<InsurancePol
 
     @Override
     protected PageableResult doGetAll(RequestContext context) throws ResponseException {
-        List<InsurancePolicy> activePolicies = Context.getService(BillingService.class)
+        List<InsurancePolicy> allPolicies = Context.getService(BillingService.class)
                 .getAllInsurancePolicies()
                 .stream()
                 .filter(policy -> !policy.isRetired())
+                .sorted((p1, p2) -> {
+                    Date d1 = p1.getCreatedDate();
+                    Date d2 = p2.getCreatedDate();
+                    if (d1 == null && d2 == null) return 0;
+                    if (d1 == null) return 1;
+                    if (d2 == null) return -1;
+                    return d2.compareTo(d1);
+                })
                 .collect(Collectors.toList());
 
-        return new NeedsPaging<>(activePolicies, context);
+        return new NeedsPaging<>(allPolicies, context);
     }
 }

--- a/omod/src/main/java/org/openmrs/module/mohbilling/rest/resource/InsurancePolicyResource.java
+++ b/omod/src/main/java/org/openmrs/module/mohbilling/rest/resource/InsurancePolicyResource.java
@@ -140,21 +140,13 @@ public class InsurancePolicyResource extends DelegatingCrudResource<InsurancePol
     }
 
     @Override
-    protected PageableResult doGetAll(RequestContext context) throws ResponseException {
-        List<InsurancePolicy> allPolicies = Context.getService(BillingService.class)
-                .getAllInsurancePolicies()
-                .stream()
-                .filter(policy -> !policy.isRetired())
-                .sorted((p1, p2) -> {
-                    Date d1 = p1.getCreatedDate();
-                    Date d2 = p2.getCreatedDate();
-                    if (d1 == null && d2 == null) return 0;
-                    if (d1 == null) return 1;
-                    if (d2 == null) return -1;
-                    return d2.compareTo(d1);
-                })
-                .collect(Collectors.toList());
+    public NeedsPaging<InsurancePolicy> doGetAll(RequestContext context) throws ResponseException {
+        int startIndex = context.getStartIndex();
+        int limit = context.getLimit();
 
-        return new NeedsPaging<>(allPolicies, context);
+        List<InsurancePolicy> policies = Context.getService(BillingService.class)
+                .getInsurancePoliciesByPagination(startIndex, limit);
+
+        return new NeedsPaging<>(policies, context);
     }
 }


### PR DESCRIPTION
- Updated InsurancePolicyResource.purge() to retire the policy
- Sets retiredBy, retiredDate, and retireReason during retirement

- Added getInsurancePoliciesByPagination(int offset, int limit) to BillingService and its implementations
- Updated InsurancePolicyResource to use doGetAll with pagination parameters (startIndex and limit)
- Ensured consistency across service, DAO, and Hibernate layers
- Refactored REST response to return paginated results via NeedsPaging

`/ws/rest/v1/mohbilling/insurancePolicy?v=default&limit=10&startIndex=0`

Optionally I updated doGetAll to exclude retired