### PR TITLE
Enable reverting of closed/paid global bill to open/unpaid status

### DIFF
--- a/api/src/main/java/org/openmrs/module/mohbilling/service/BillingService.java
+++ b/api/src/main/java/org/openmrs/module/mohbilling/service/BillingService.java
@@ -10,7 +10,6 @@ import org.openmrs.api.db.DAOException;
 import org.openmrs.module.mohbilling.model.*;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -749,4 +748,14 @@ public interface BillingService {
 	 */
 	List<Consommation> getNewestConsommations(Integer startIndex, Integer pageSize,
 											  String orderBy, String orderDirection);
+
+	/**
+	 * Reverts a closed bill back to unpaid status
+	 * @param globalBillId the ID of the bill to revert
+	 * @param reason the reason for reverting the bill
+	 * @param revertedBy the user performing the revert
+	 * @return the reverted GlobalBill
+	 * @throws DAOException if the operation fails
+	 */
+	public GlobalBill revertClosedBill(Integer globalBillId, String reason, User revertedBy) throws DAOException;
 }

--- a/omod/src/main/java/org/openmrs/module/mohbilling/rest/controller/BillingController.java
+++ b/omod/src/main/java/org/openmrs/module/mohbilling/rest/controller/BillingController.java
@@ -4,11 +4,15 @@ import java.math.BigDecimal;
 import java.util.Map;
 
 import org.openmrs.api.context.Context;
+import org.openmrs.module.mohbilling.rest.dto.RevertGlobalBillResponse;
 import org.openmrs.module.mohbilling.service.BillingService;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceController;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -29,5 +33,45 @@ public class BillingController extends MainResourceController {
         BillingService billingService = Context.getService(BillingService.class);
         Map<String, BigDecimal> summary = billingService.getGlobalBillsSummary();
         return ResponseEntity.ok(summary);
+    }
+
+    /**
+     * Reverts a closed global bill back to unpaid status
+     * POST /rest/v1/mohbilling/globalBill/{id}/revert
+     * 
+     * @param id the global bill ID to revert
+     * @param requestBody containing the reason for reverting
+     * @return ResponseEntity with the revert response or error message
+     */
+    @RequestMapping(value = "/globalBill/{id}/revert", method = RequestMethod.POST)
+    public ResponseEntity<?> revertGlobalBill(@PathVariable("id") String id, 
+                                            @RequestBody Map<String, String> requestBody) {
+        try {
+            Integer globalBillId = Integer.valueOf(id);
+            String reason = requestBody.get("reason");
+            
+            if (reason == null || reason.trim().isEmpty()) {
+                return ResponseEntity.badRequest()
+                    .body("Reason for reverting bill is required");
+            }
+            
+            BillingService billingService = Context.getService(BillingService.class);
+            billingService.revertClosedBill(globalBillId, reason, Context.getAuthenticatedUser());
+
+            RevertGlobalBillResponse response = new RevertGlobalBillResponse(
+                globalBillId, 
+                reason, 
+                Context.getAuthenticatedUser().getUsername()
+            );
+            
+            return ResponseEntity.ok(response);
+            
+        } catch (NumberFormatException e) {
+            return ResponseEntity.badRequest()
+                .body("Invalid global bill ID: " + id);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("Error reverting bill: " + e.getMessage());
+        }
     }
 }

--- a/omod/src/main/java/org/openmrs/module/mohbilling/rest/dto/RevertGlobalBillResponse.java
+++ b/omod/src/main/java/org/openmrs/module/mohbilling/rest/dto/RevertGlobalBillResponse.java
@@ -1,0 +1,86 @@
+package org.openmrs.module.mohbilling.rest.dto;
+
+import java.util.Date;
+
+/**
+ * Simple response DTO for GlobalBill revert operation
+ */
+public class RevertGlobalBillResponse {
+    
+    private Integer globalBillId;
+    private Boolean closed;
+    private Date closingDate;
+    private String closedBy;
+    private String editingReason;
+    private String editedBy;
+    private String message;
+    
+    public RevertGlobalBillResponse() {}
+    
+    public RevertGlobalBillResponse(Integer globalBillId, String editingReason, String editedBy) {
+        this.globalBillId = globalBillId;
+        this.closed = false;
+        this.closingDate = null;
+        this.closedBy = null;
+        this.editingReason = editingReason;
+        this.editedBy = editedBy;
+        this.message = "Global bill successfully reverted to unpaid status";
+    }
+    
+    // Getters and Setters
+    public Integer getGlobalBillId() {
+        return globalBillId;
+    }
+    
+    public void setGlobalBillId(Integer globalBillId) {
+        this.globalBillId = globalBillId;
+    }
+    
+    public Boolean getClosed() {
+        return closed;
+    }
+    
+    public void setClosed(Boolean closed) {
+        this.closed = closed;
+    }
+    
+    public Date getClosingDate() {
+        return closingDate;
+    }
+    
+    public void setClosingDate(Date closingDate) {
+        this.closingDate = closingDate;
+    }
+    
+    public String getClosedBy() {
+        return closedBy;
+    }
+    
+    public void setClosedBy(String closedBy) {
+        this.closedBy = closedBy;
+    }
+    
+    public String getEditingReason() {
+        return editingReason;
+    }
+    
+    public void setEditingReason(String editingReason) {
+        this.editingReason = editingReason;
+    }
+    
+    public String getEditedBy() {
+        return editedBy;
+    }
+    
+    public void setEditedBy(String editedBy) {
+        this.editedBy = editedBy;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+    
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/mohbilling/rest/resource/GlobalBillResource.java
+++ b/omod/src/main/java/org/openmrs/module/mohbilling/rest/resource/GlobalBillResource.java
@@ -260,7 +260,7 @@ public class GlobalBillResource extends DelegatingCrudResource<GlobalBill> {
             hasMore = page.size() >= limit;
         }
 
-        return new org.openmrs.module.webservices.rest.web.resource.impl.AlreadyPaged<GlobalBill>(context, page, hasMore);
+        return new AlreadyPaged<GlobalBill>(context, page, hasMore);
     }
 
 }


### PR DESCRIPTION
Endpoint: `/ws/rest/v1/mohbilling/globalBill/1063096/revert`

Body: 

> {
  "reason": "Missing Items"
}

Response JSON structure:

> {
    "globalBillId": 1063096,
    "closed": false,
    "closingDate": null,
    "closedBy": null,
    "editingReason": "Missing Items",
    "editedBy": "admin",
    "message": "Global bill successfully reverted to unpaid status"
}